### PR TITLE
Allow a single test to be executed by line number

### DIFF
--- a/lib/test_bench/cli/cli.rb
+++ b/lib/test_bench/cli/cli.rb
@@ -75,6 +75,10 @@ If no paths are specified, #{program_name} runs all files in ./tests. The follow
         parser.on '-x', '--exclude PATTERN', %{Filter out files matching PATTERN (Default is "_init$")} do |pattern|
           settings.exclude_pattern = pattern
         end
+
+        parser.on '-l', '--line N', "Run a single test at the N-th line" do |n|
+          settings.line_number = n.to_i
+        end
       end
     end
 

--- a/lib/test_bench/cli/cli.rb
+++ b/lib/test_bench/cli/cli.rb
@@ -20,6 +20,11 @@ module TestBench
 
       paths = argv
       paths << 'tests' if paths.empty?
+      if paths.length == 1
+        path, line_number = paths[0].split(':')
+        settings.line_number = line_number
+        paths = [path]
+      end
 
       current_directory = File.expand_path Dir.pwd
 
@@ -74,10 +79,6 @@ If no paths are specified, #{program_name} runs all files in ./tests. The follow
 
         parser.on '-x', '--exclude PATTERN', %{Filter out files matching PATTERN (Default is "_init$")} do |pattern|
           settings.exclude_pattern = pattern
-        end
-
-        parser.on '-l', '--line N', "Run a single test at the N-th line" do |n|
-          settings.line_number = n.to_i
         end
       end
     end

--- a/lib/test_bench/executor.rb
+++ b/lib/test_bench/executor.rb
@@ -2,16 +2,19 @@ module TestBench
   class Executor
     attr_reader :binding
     attr_reader :file_module
+    attr_reader :line_number
 
-    def initialize binding, file_module
+    def initialize binding, file_module, line_number = nil
       @binding = binding
       @file_module = file_module
+      @line_number = line_number
     end
 
     def self.build
       binding = TOPLEVEL_BINDING
+      line_number = Settings.toplevel.line_number
 
-      new binding, File
+      new binding, File, line_number
     end
 
     def call files
@@ -28,7 +31,7 @@ module TestBench
       telemetry.file_started file
 
       begin
-        binding.receiver.context :suppress_exit => true do
+        binding.receiver.context :suppress_exit => true, :line_number => line_number do
           binding.eval test_script, file
         end
 

--- a/lib/test_bench/executor.rb
+++ b/lib/test_bench/executor.rb
@@ -2,19 +2,16 @@ module TestBench
   class Executor
     attr_reader :binding
     attr_reader :file_module
-    attr_reader :line_number
 
-    def initialize binding, file_module, line_number = nil
+    def initialize binding, file_module
       @binding = binding
       @file_module = file_module
-      @line_number = line_number
     end
 
     def self.build
       binding = TOPLEVEL_BINDING
-      line_number = Settings.toplevel.line_number
 
-      new binding, File, line_number
+      new binding, File
     end
 
     def call files
@@ -31,7 +28,7 @@ module TestBench
       telemetry.file_started file
 
       begin
-        binding.receiver.context :suppress_exit => true, :line_number => line_number do
+        binding.receiver.context :suppress_exit => true do
           binding.eval test_script, file
         end
 

--- a/lib/test_bench/settings.rb
+++ b/lib/test_bench/settings.rb
@@ -5,7 +5,7 @@ module TestBench
     attr_writer :writer
     attr_writer :record_telemetry
     attr_writer :reverse_backtraces
-    attr_accessor :line_number
+    attr_reader :line_number
 
     def abort_on_error
       nil_coalesce :@abort_on_error, Defaults.abort_on_error
@@ -49,6 +49,15 @@ module TestBench
 
     def writer
       @writer ||= Output::Writer.new
+    end
+
+    def line_number= value
+      value = value.to_i
+      if value > 0
+        @line_number = value 
+      else
+        @line_number = nil
+      end
     end
 
     def self.toplevel

--- a/lib/test_bench/settings.rb
+++ b/lib/test_bench/settings.rb
@@ -5,6 +5,7 @@ module TestBench
     attr_writer :writer
     attr_writer :record_telemetry
     attr_writer :reverse_backtraces
+    attr_accessor :line_number
 
     def abort_on_error
       nil_coalesce :@abort_on_error, Defaults.abort_on_error

--- a/lib/test_bench/structure.rb
+++ b/lib/test_bench/structure.rb
@@ -14,10 +14,8 @@ module TestBench
       telemetry.asserted
     end
 
-    def context prose=nil, suppress_exit: nil, line_number: nil, &block
+    def context prose=nil, suppress_exit: nil, &block
       suppress_exit ||= false
-
-      @line_number = line_number if line_number
 
       telemetry = Telemetry::Registry.get binding
       settings = Settings::Registry.get binding
@@ -48,8 +46,11 @@ module TestBench
     end
 
     def test prose=nil, &block
-      return if @line_number && @line_number != block.source_location[1]
       telemetry = Telemetry::Registry.get binding
+      settings = Settings::Registry.get binding
+      line_number = settings.line_number
+      require 'pry'
+      return if line_number && line_number != block.source_location[1]
 
       prose ||= 'Test'
 

--- a/lib/test_bench/structure.rb
+++ b/lib/test_bench/structure.rb
@@ -14,8 +14,10 @@ module TestBench
       telemetry.asserted
     end
 
-    def context prose=nil, suppress_exit: nil, &block
+    def context prose=nil, suppress_exit: nil, line_number: nil, &block
       suppress_exit ||= false
+
+      @line_number = line_number if line_number
 
       telemetry = Telemetry::Registry.get binding
       settings = Settings::Registry.get binding
@@ -32,6 +34,7 @@ module TestBench
         Structure.error error, binding
 
       ensure
+        @test_instance = nil
         nesting = telemetry.context_exited prose
 
         if nesting.zero? and telemetry.failed?
@@ -45,6 +48,7 @@ module TestBench
     end
 
     def test prose=nil, &block
+      return if @line_number && @line_number != block.source_location[1]
       telemetry = Telemetry::Registry.get binding
 
       prose ||= 'Test'

--- a/tests/settings.rb
+++ b/tests/settings.rb
@@ -108,6 +108,30 @@ context "Settings" do
       assert settings.line_number == 10
     end
 
+    test "Will convert a string" do
+      settings = TestBench::Settings.new
+
+      settings.line_number = "10"
+
+      assert settings.line_number == 10
+    end
+
+    test "Will be nil on an invalid string" do
+      settings = TestBench::Settings.new
+
+      settings.line_number = "bad value"
+
+      assert settings.line_number.nil?
+    end
+
+    test "Will be nil on a negative number" do
+      settings = TestBench::Settings.new
+
+      settings.line_number = -10
+
+      assert settings.line_number.nil?
+    end
+
     test "Default is nil" do
       settings = TestBench::Settings.new
 

--- a/tests/settings.rb
+++ b/tests/settings.rb
@@ -98,4 +98,20 @@ context "Settings" do
       assert settings.record_telemetry == false
     end
   end
+
+  context "Line number" do
+    test do
+      settings = TestBench::Settings.new
+
+      settings.line_number = 10
+
+      assert settings.line_number == 10
+    end
+
+    test "Default is nil" do
+      settings = TestBench::Settings.new
+
+      assert settings.line_number.nil?
+    end
+  end
 end

--- a/tests/single_test.rb
+++ b/tests/single_test.rb
@@ -1,7 +1,11 @@
 require_relative './test_init'
 
 context 'Running a single test by line number' do
-  context 'Choose a test by line number', line_number: 9 do
+  settings = TestBench::Settings::Registry.get binding
+
+  context 'Choose a test by line number' do
+    settings.line_number = 13
+
     test "Will not call this test" do
       refute true
     end
@@ -11,7 +15,8 @@ context 'Running a single test by line number' do
     end
   end
 
-  context 'Choose a test by number...', line_number: 20 do
+  context 'Choose a test by number...' do
+    settings.line_number = 25
     context '...in a nested context' do
       test "Will not call this test" do
         refute true

--- a/tests/single_test.rb
+++ b/tests/single_test.rb
@@ -1,0 +1,25 @@
+require_relative './test_init'
+
+context 'Running a single test by line number' do
+  context 'Choose a test by line number', line_number: 9 do
+    test "Will not call this test" do
+      refute true
+    end
+
+    test "Will call this test" do
+      assert true
+    end
+  end
+
+  context 'Choose a test by number...', line_number: 20 do
+    context '...in a nested context' do
+      test "Will not call this test" do
+        refute true
+      end
+
+      test "Will call this test" do
+        assert true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Can specify a line number as an option when declaring a context block. The tests within that context block will only execute if their block source_location matches that line number.

The CLI interface is:

`test my_test.rb -l5` or `test my_test.rb --line 5`